### PR TITLE
Replace %f with %g in format strings

### DIFF
--- a/2csv.c
+++ b/2csv.c
@@ -37,10 +37,10 @@ static int msg2csv(can_msg_t *msg, FILE *o)
 		fprintf(o, "%u, ", sig->start_bit);
 		fprintf(o, "%u, ", sig->bit_length);
 		fprintf(o, "%s, ", sig->endianess == endianess_motorola_e ? "motorola" : "intel");
-		fprintf(o, "%f, ", sig->scaling);
-		fprintf(o, "%f, ", sig->offset);
-		fprintf(o, "%f, ", sig->minimum);
-		fprintf(o, "%f, ", sig->maximum);
+		fprintf(o, "%g, ", sig->scaling);
+		fprintf(o, "%g, ", sig->offset);
+		fprintf(o, "%g, ", sig->minimum);
+		fprintf(o, "%g, ", sig->maximum);
 		fprintf(o, "%s, ", sig->is_signed ? "true" : "false");
 		bool have_units = false;
 		const char *units = sig->units;

--- a/2xml.c
+++ b/2xml.c
@@ -107,10 +107,10 @@ static int signal2xml(signal_t *sig, FILE *o, unsigned depth)
 	pnode(o, depth+1, "startbit",  "%u", sig->start_bit);
 	pnode(o, depth+1, "bitlength", "%u", sig->bit_length);
 	pnode(o, depth+1, "endianess", "%s", sig->endianess == endianess_motorola_e ? "motorola" : "intel");
-	pnode(o, depth+1, "scaling",   "%f", sig->scaling);
-	pnode(o, depth+1, "offset",    "%f", sig->offset);
-	pnode(o, depth+1, "minimum",   "%f", sig->minimum);
-	pnode(o, depth+1, "maximum",   "%f", sig->maximum);
+	pnode(o, depth+1, "scaling",   "%g", sig->scaling);
+	pnode(o, depth+1, "offset",    "%g", sig->offset);
+	pnode(o, depth+1, "minimum",   "%g", sig->minimum);
+	pnode(o, depth+1, "maximum",   "%g", sig->maximum);
 	pnode(o, depth+1, "signed",    "%s", sig->is_signed ? "true" : "false");
 	pnode(o, depth+1, "floating",  "%u", sig->is_floating ? sig->sigval : 0);
 


### PR DESCRIPTION
The %f format character forces a decimal notation, which does not
produce correct values for exponents smaller than 1e-6. In most cases,
%g also uses the decimal notation, except when the value is way too
large, or small.

(See issue #21 )