### PR TITLE
Add support for value lists

### DIFF
--- a/can.c
+++ b/can.c
@@ -315,18 +315,20 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 	// find and store the vals into the dbc: they will be assigned to
 	// signals later
 	mpc_ast_t *vals_ast = mpc_ast_get_child_lb(ast, "vals|>", 0);
-	d->val_count = vals_ast->children_num;
-	d->vals = allocate(sizeof(*d->vals) * (d->val_count+1));
-	if (d->val_count) {
-		int j = 0;
-		for(int i = 0; i >= 0;) {
-			i = mpc_ast_get_index_lb(vals_ast, "val|>", i);
-			if(i >= 0) {
-				mpc_ast_t *val_ast = mpc_ast_get_child_lb(vals_ast, "val|>", i);
-				d->vals[j++] = ast2val(ast, val_ast);
-				i++;
+	if (vals_ast) {
+		d->val_count = vals_ast->children_num;
+		d->vals = allocate(sizeof(*d->vals) * (d->val_count+1));
+		if (d->val_count) {
+			int j = 0;
+			for(int i = 0; i >= 0;) {
+				i = mpc_ast_get_index_lb(vals_ast, "val|>", i);
+				if(i >= 0) {
+					mpc_ast_t *val_ast = mpc_ast_get_child_lb(vals_ast, "val|>", i);
+					d->vals[j++] = ast2val(ast, val_ast);
+					i++;
+				}
 			}
-        }
+		}
 	}
 
 	int index     = mpc_ast_get_index_lb(ast, "messages|>", 0);

--- a/can.c
+++ b/can.c
@@ -45,6 +45,17 @@ static void can_msg_delete(can_msg_t *msg)
 	free(msg);
 }
 
+static void val_delete(val_list_t *val)
+{
+    if(!val)
+        return;
+    for(size_t i = 0; i < val->val_list_item_count; i++) {
+        free(val->val_list_items[i]->name);
+        free(val->val_list_items[i]);
+    }
+    free(val);
+}
+
 static void y_mx_c(mpc_ast_t *ast, signal_t *sig)
 {
 	assert(ast && sig);
@@ -267,9 +278,11 @@ dbc_t *dbc_new(void)
 void dbc_delete(dbc_t *dbc)
 {
 	if(!dbc)
-		return;
-	for(int i = 0; i < dbc->message_count; i++)
-		can_msg_delete(dbc->messages[i]);
+        return;
+    for(int i = 0; i < dbc->message_count; i++)
+        can_msg_delete(dbc->messages[i]);
+    for(size_t i = 0; i < dbc->val_count; i++)
+        val_delete(dbc->vals[i]);
 	free(dbc);
 }
 

--- a/can.c
+++ b/can.c
@@ -204,8 +204,26 @@ static val_list_t *ast2val(mpc_ast_t *top, mpc_ast_t *ast)
 			i++;
 		}
 	}
+
 	val->val_list_item_count = j;
-	val->val_list_items = items;
+    val->val_list_items = items;
+
+    // sort the value items by value
+    if (val->val_list_item_count) {
+        bool bFlip = false;
+        do {
+            bFlip = false;
+            for (size_t i = 0; i < val->val_list_item_count - 1; i++) {
+                if (val->val_list_items[i]->value > val->val_list_items[i + 1]->value) {
+                    val_list_item_t *tmp = val->val_list_items[i];
+                    val->val_list_items[i] = val->val_list_items[i + 1];
+                    val->val_list_items[i + 1] = tmp;
+                    bFlip = true;
+                }
+            }
+        } while (bFlip);
+    }
+
 	return val;
 }
 
@@ -279,10 +297,14 @@ void dbc_delete(dbc_t *dbc)
 {
 	if(!dbc)
         return;
-    for(int i = 0; i < dbc->message_count; i++)
+    for(int i = 0; i < dbc->message_count; i++) {
         can_msg_delete(dbc->messages[i]);
-    for(size_t i = 0; i < dbc->val_count; i++)
+    }
+
+    for(size_t i = 0; i < dbc->val_count; i++) {
         val_delete(dbc->vals[i]);
+    }
+
 	free(dbc);
 }
 
@@ -304,7 +326,7 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 				d->vals[j++] = ast2val(ast, val_ast);
 				i++;
 			}
-		}
+        }
 	}
 
 	int index     = mpc_ast_get_index_lb(ast, "messages|>", 0);

--- a/can.c
+++ b/can.c
@@ -119,6 +119,7 @@ static signal_t *ast2signal(mpc_ast_t *top, mpc_ast_t *ast, unsigned can_id)
 	mpc_ast_t *endianess = mpc_ast_get_child(ast, "endianess|char");
 	mpc_ast_t *sign   = mpc_ast_get_child(ast, "sign|char");
 	sig->name = duplicate(name->contents);
+	sig->val_list = NULL;
 	r = sscanf(start->contents, "%u", &sig->start_bit);
 	assert(r == 1 && sig->start_bit <= 64);
 	r = sscanf(length->contents, "%u", &sig->bit_length);
@@ -160,7 +161,44 @@ static signal_t *ast2signal(mpc_ast_t *top, mpc_ast_t *ast, unsigned can_id)
 	return sig;
 }
 
-static can_msg_t *ast2msg(mpc_ast_t *top, mpc_ast_t *ast)
+static val_list_t *ast2val(mpc_ast_t *top, mpc_ast_t *ast)
+{
+	assert(top);
+	assert(ast);
+	val_list_t *val = allocate(sizeof(val_list_t));
+
+	mpc_ast_t *id   = mpc_ast_get_child(ast, "id|integer|regex");
+	int r = sscanf(id->contents,  "%u",  &val->id);
+	assert(r == 1);
+
+	mpc_ast_t *name = mpc_ast_get_child(ast, "name|ident|regex");
+	val->name = duplicate(name->contents);
+
+	val_list_item_t **items = allocate(sizeof(*items) * (ast->children_num+1));
+	int j = 0;
+	for(int i = 0; i >= 0;) {
+		i = mpc_ast_get_index_lb(ast, "val_item|>", i);
+		if(i >= 0) {
+			val_list_item_t *item = allocate(sizeof(val_list_item_t));
+			mpc_ast_t *val_item_ast = mpc_ast_get_child_lb(ast, "val_item|>", i);
+
+			mpc_ast_t *val_item_index = mpc_ast_get_child(val_item_ast, "integer|regex");
+			int r = sscanf(val_item_index->contents,  "%u",  &item->value);
+			assert(r == 1);
+
+			mpc_ast_t *val_item_name = mpc_ast_get_child(val_item_ast, "string|>");
+			val_item_name = mpc_ast_get_child_lb(val_item_name, "regex", 1);
+			item->name = duplicate(val_item_name->contents);
+			items[j++] = item;
+			i++;
+		}
+	}
+	val->val_list_item_count = j;
+	val->val_list_items = items;
+	return val;
+}
+
+static can_msg_t *ast2msg(mpc_ast_t *top, mpc_ast_t *ast, dbc_t *dbc)
 {
 	assert(top);
 	assert(ast);
@@ -191,6 +229,16 @@ static can_msg_t *ast2msg(mpc_ast_t *top, mpc_ast_t *ast)
 
 	c->sigs = signal_s;
 	c->signal_count = j;
+
+	// assign val-s to the signals
+	for (size_t i = 0; i < c->signal_count; i++) {
+		for (size_t j = 0; j<dbc->val_count; j++) {
+			if (dbc->vals[j]->id == c->id && strcmp(dbc->vals[j]->name, c->sigs[i]->name) == 0) {
+				c->sigs[i]->val_list = dbc->vals[j];
+				break;
+			}
+		}
+	}
 
 	if (c->signal_count > 1) { // Lets sort the signals so that their start_bit is asc (lowest number first)
 		bool bFlip = false;
@@ -227,7 +275,26 @@ void dbc_delete(dbc_t *dbc)
 
 dbc_t *ast2dbc(mpc_ast_t *ast)
 {
-	const int index     = mpc_ast_get_index_lb(ast, "messages|>", 0);
+	dbc_t *d = dbc_new();
+
+	// find and store the vals into the dbc: they will be assigned to
+	// signals later
+	mpc_ast_t *vals_ast = mpc_ast_get_child_lb(ast, "vals|>", 0);
+	d->val_count = vals_ast->children_num;
+	d->vals = allocate(sizeof(*d->vals) * (d->val_count+1));
+	if (d->val_count) {
+		int j = 0;
+		for(int i = 0; i >= 0;) {
+			i = mpc_ast_get_index_lb(vals_ast, "val|>", i);
+			if(i >= 0) {
+				mpc_ast_t *val_ast = mpc_ast_get_child_lb(vals_ast, "val|>", i);
+				d->vals[j++] = ast2val(ast, val_ast);
+				i++;
+			}
+		}
+	}
+
+	int index     = mpc_ast_get_index_lb(ast, "messages|>", 0);
 	mpc_ast_t *msgs_ast = mpc_ast_get_child_lb(ast, "messages|>", 0);
 	if(index < 0) {
 		warning("no messages found");
@@ -240,14 +307,13 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 		return NULL;
 	}
 
-	dbc_t *d = dbc_new();
 	can_msg_t **r = allocate(sizeof(*r) * (n+1));
 	int j = 0;
 	for(int i = 0; i >= 0;) {
 		i = mpc_ast_get_index_lb(msgs_ast, "message|>", i);
 		if(i >= 0) {
 			mpc_ast_t *msg_ast = mpc_ast_get_child_lb(msgs_ast, "message|>", i);
-			r[j++] = ast2msg(ast, msg_ast);
+			r[j++] = ast2msg(ast, msg_ast, d);
 			i++;
 		}
 	}

--- a/can.h
+++ b/can.h
@@ -22,6 +22,18 @@ typedef enum {
 } numeric_e;
 
 typedef struct {
+	char *name;
+	unsigned value;
+} val_list_item_t;
+
+typedef struct {
+	size_t val_list_item_count;
+	val_list_item_t **val_list_items;
+	unsigned id;   /**< identifier, 11 or 29 bit */
+	char *name;
+} val_list_t;
+
+typedef struct {
 	size_t ecu_count;    /**< ECU count */
 	char *units;         /**< units used */
 	char **ecus;         /**< ECUs sending/receiving */
@@ -40,6 +52,7 @@ typedef struct {
 	bool is_multiplexed; /**< true if this is a multiplexed signal */
 	unsigned switchval;  /**< if is_multiplexed, this will contain the
 			       value that decodes this signal for the multiplexor */
+	val_list_t *val_list;
 } signal_t;
 
 typedef struct {
@@ -56,6 +69,9 @@ typedef struct {
 	bool use_float; /**< floating point conversion routines are needed */
 	int message_count;
 	can_msg_t **messages;
+
+	val_list_t **vals;
+	size_t val_count;
 } dbc_t;
 
 dbc_t *ast2dbc(mpc_ast_t *ast);

--- a/parse.c
+++ b/parse.c
@@ -40,6 +40,14 @@ static mpc_ast_t *_parse_dbc_file_by_handle(const char *name, FILE *handle);
 	X(sigval,     "sigval")\
 	X(whatever,   "whatever")\
 	X(values,     "values")\
+	X(val_cnt,    "val_cnt")\
+	X(val_name,   "val_name")\
+	X(val_index,  "val_index")\
+	X(val,        "val")\
+	X(attribute_definition, "attribute_definition")\
+	X(attribute_value, "attribute_value")\
+	X(comment,    "comment")\
+	X(comment_string,    "comment_string")\
 	X(dbc,        "dbc")
 
 /**@todo This grammar needs expanding and fixing, one addition would be comment lines,
@@ -47,43 +55,59 @@ static mpc_ast_t *_parse_dbc_file_by_handle(const char *name, FILE *handle);
  * Ideally the grammar would be rewritten, to follow Vectors documentation on it. */
 
 static const char *dbc_grammar =
-" s         : /[ \\t]/ ; \n"
-" n         : /\\r?\\n/ ; \n"
-" sign      : '+' | '-' ; \n"
-" float     : /[-+]?[0-9]+(\\.[0-9]+)?([eE][-+]?[0-9]+)?/ ; \n"
-" ident     : /[a-zA-Z_][a-zA-Z0-9_]*/ ;\n"
-" integer   : <sign>? /[0-9]+/ ; \n"
-" factor    : <float> | <integer> ; \n"
-" offset    : <float> | <integer> ; \n"
-" length    : /[0-9]+/ ; \n"
-" range     : '[' ( <float> | <integer> ) '|' ( <float> | <integer> ) ']' ;\n"
-" node      : <ident> ; \n"
-" nodes     : <node> <s>* ( ',' <s>* <node>)* ; \n"
-" string    : '\"' /[^\"]*/ '\"' \n; "
-" unit      : <string> ; \n"
-" startbit  : <integer> ; \n"
-" endianess : '0' | '1' ; \n" /* for the endianess; 0 = Motorola, 1 = Intel */
-" y_mx_c    : '(' <factor> ',' <offset> ')' ; \n"
-" name      : <ident> ; \n"
-" ecu       : <ident> ; \n"
-" dlc       : <integer> ; \n"
-" id        : <integer> ; \n"
-" multiplexor : 'M' | 'm' <s>* <integer> ; \n"
-" signal    : <s>* \"SG_\" <s>+ <name> <s>* <multiplexor>? <s>* ':' <s>* <startbit> <s>* '|' <s>* \n"
-"             <length> <s>* '@' <s>* <endianess> <s>* <sign> <s>* <y_mx_c> <s>* \n"
-"             <range> <s>* <unit> <s>* <nodes> <s>* <n> ; \n"
-" message   : \"BO_\" <s>+ <id> <s>+ <name>  <s>* ':' <s>* <dlc> <s>+ <ecu> <s>* <n> <signal>* ; \n"
-" messages  : (<message> <n>+)* ; \n"
-" version   : \"VERSION\" <s> <string> <n>+ ; \n"
-" ecus      : \"BU_\" <s>* ':' (<ident>|<s>)* <n> ; \n"
-" symbols   : \"NS_\" <s>* ':' <s>* <n> ('\t' <ident> <n>)* <n> ; \n"
-" sigtype   : <integer>  ;\n"
-" sigval    : <s>* \"SIG_VALTYPE_\" <s>+ <id> <s>+ <name> <s>* \":\" <s>* <sigtype> <s>* ';' <n>* ; \n"
-" whatever  : (<ident>|<string>|<integer>|<float>) ; \n"
-" bs        : \"BS_\" <s>* ':' <n>+ ; "
-" types     : <s>* <ident> (<whatever>|<s>)+ ';' (<n>*|/$/) ; \n"
-" values    : \"VAL_TABLE_\" (<whatever>|<s>)* ';' <n> ; \n" /**@note don't care about this, for now*/
-" dbc       : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> (<sigval>|<types>)*  ; \n" ;
+" s                    : /[ \\t]/ ; \n"
+" n                    : /\\r?\\n/ ; \n"
+" sign                 : '+' | '-' ; \n"
+" float                : /[-+]?[0-9]+(\\.[0-9]+)?([eE][-+]?[0-9]+)?/ ; \n"
+" ident                : /[a-zA-Z_][a-zA-Z0-9_]*/ ;\n"
+" integer              : <sign>? /[0-9]+/ ; \n"
+" factor               : <float> | <integer> ; \n"
+" offset               : <float> | <integer> ; \n"
+" length               : /[0-9]+/ ; \n"
+" range                : '[' ( <float> | <integer> ) '|' ( <float> | <integer> ) ']' ;\n"
+" node                 : <ident> ; \n"
+" nodes                : <node> <s>* ( ',' <s>* <node>)* ; \n"
+" string               : '\"' /[^\"]*/ '\"' \n; "
+" unit                 : <string> ; \n"
+" startbit             : <integer> ; \n"
+" endianess            : '0' | '1' ; \n" /* for the endianess; 0 = Motorola, 1 = Intel */
+" y_mx_c               : '(' <factor> ',' <offset> ')' ; \n"
+" name                 : <ident> ; \n"
+" ecu                  : <ident> ; \n"
+" dlc                  : <integer> ; \n"
+" id                   : <integer> ; \n"
+" multiplexor          : 'M' | 'm' <s>* <integer> ; \n"
+" signal               : <s>* \"SG_\" <s>+ <name> <s>* <multiplexor>? <s>* ':' <s>* <startbit> <s>* '|' <s>* \n"
+"                        <length> <s>* '@' <s>* <endianess> <s>* <sign> <s>* <y_mx_c> <s>* \n"
+"                        <range> <s>* <unit> <s>* <nodes> <s>* <n> ; \n"
+" message              : \"BO_\" <s>+ <id> <s>+ <name>  <s>* ':' <s>* <dlc> <s>+ <ecu> <s>* <n> <signal>* ; \n"
+" messages             : (<message> <n>*)* ; \n"
+" version              : \"VERSION\" <s> <string> <n>+ ; \n"
+" ecus                 : \"BU_\" <s>* ':' (<ident>|<s>)* <n> ; \n"
+" symbols              : \"NS_\" <s>* ':' <s>* <n> ('\t' <ident> <n>)* <n> ; \n"
+" sigtype              : <integer>  ;\n"
+" sigval               : <s>* \"SIG_VALTYPE_\" <s>+ <id> <s>+ <name> <s>* \"           :\" <s>* <sigtype> <s>* ';' <n>* ; \n"
+" whatever             : (<ident>|<string>|<integer>|<float>) ; \n"
+" bs                   : \"BS_\" <s>* ':' <n>+ ; "
+" types                : <s>* <ident> (<whatever>|<s>)+ ';' <n> ; \n"
+" values               : \"VAL_TABLE_\" (<whatever>|<s>)* ';' <n> ; \n" /**@note don't care about this, for now*/
+" val_cnt              : <integer> ; \n"
+" val_name			   : <string> ; \n"
+" val_index			   : <integer> ; \n"
+" attribute_definition : \"BA_DEF_\" (<whatever>|<s>|',')* ';' <n> ; \n" /**@note don't care about this, for now*/
+" attribute_value      : \"BA_\" (<whatever>|<s>|',')* ';' <n> ; \n" /**@note don't care about this, for now*/
+" val                  : \"VAL_\" <s>+ <id> <s>+ <name> <s>+ (<val_index> <s>+ <val_name> <s>)* ';' <n> ; \n"
+" comment_string       : <string> ; \n"
+" env_var_name         : <ident> ; \n"
+" comment              : \"CM_\" <s>+ "
+"                        ( "
+"                            \"SG_\" <s>+ <id> <s>+ <name> <s>+ <comment_string> "
+"                        |    \"BU_\" <s>+ <name> <s>+ <comment_string> "
+"                        |    \"BO_\" <s>+ <id> <s>+ <comment_string> "
+"                        |    \"EV_\" <s>+ <env_var_name> <s>+ <comment_string> "
+"                        |    <comment_string> "
+"                        ) <s>* ';' <n> ;\n "
+" dbc                  : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> <comment>* <attribute_definition>* <attribute_value>* <val>* ; \n" ;
 
 const char *parse_get_grammar(void)
 {

--- a/parse.c
+++ b/parse.c
@@ -6,49 +6,48 @@ static mpc_ast_t *_parse_dbc_string(const char *file_name, const char *string);
 static mpc_ast_t *_parse_dbc_file_by_handle(const char *name, FILE *handle);
 
 #define X_MACRO_PARSE_VARS\
-	X(spaces,     "s")\
-	X(newline,    "n")\
-	X(sign,       "sign")\
-	X(flt,        "float")\
-	X(ident,      "ident")\
-	X(integer,    "integer")\
-	X(factor,     "factor")\
-	X(offset,     "offset")\
-	X(range,      "range")\
-	X(length,     "length")\
-	X(node,       "node")\
-	X(nodes,      "nodes")\
-	X(stringp,    "string")\
-	X(unit,       "unit")\
-	X(startbit,   "startbit")\
-	X(endianess,  "endianess")\
-	X(y_mx_c,     "y_mx_c")\
-	X(name,       "name")\
-	X(ecu,        "ecu")\
-	X(dlc,        "dlc")\
-	X(id,         "id")\
-	X(multiplexor, "multiplexor")\
-	X(signal,     "signal")\
-	X(message,    "message")\
-	X(messages,   "messages")\
-	X(types,      "types")\
-	X(version,    "version")\
-	X(ecus,       "ecus")\
-	X(symbols,    "symbols")\
-	X(bs,         "bs")\
-	X(sigtype,    "sigtype")\
-	X(sigval,     "sigval")\
-	X(whatever,   "whatever")\
-	X(values,     "values")\
-	X(val_cnt,    "val_cnt")\
-	X(val_name,   "val_name")\
-	X(val_index,  "val_index")\
-	X(val,        "val")\
+	X(spaces,               "s")\
+	X(newline,              "n")\
+	X(sign,                 "sign")\
+	X(flt,                  "float")\
+	X(ident,                "ident")\
+	X(integer,              "integer")\
+	X(factor,               "factor")\
+	X(offset,               "offset")\
+	X(range,                "range")\
+	X(length,               "length")\
+	X(node,                 "node")\
+	X(nodes,                "nodes")\
+	X(stringp,              "string")\
+	X(unit,                 "unit")\
+	X(startbit,             "startbit")\
+	X(endianess,            "endianess")\
+	X(y_mx_c,               "y_mx_c")\
+	X(name,                 "name")\
+	X(ecu,                  "ecu")\
+	X(dlc,                  "dlc")\
+	X(id,                   "id")\
+	X(multiplexor,          "multiplexor")\
+	X(signal,               "signal")\
+	X(message,              "message")\
+	X(messages,             "messages")\
+	X(types,                "types")\
+	X(version,              "version")\
+	X(ecus,                 "ecus")\
+	X(symbols,              "symbols")\
+	X(bs,                   "bs")\
+	X(sigtype,              "sigtype")\
+	X(sigval,               "sigval")\
+	X(whatever,             "whatever")\
+	X(values,               "values")\
+	X(val_item,             "val_item")\
+	X(val,                  "val")\
+	X(vals,                 "vals")\
 	X(attribute_definition, "attribute_definition")\
-	X(attribute_value, "attribute_value")\
-	X(comment,    "comment")\
-	X(comment_string,    "comment_string")\
-	X(dbc,        "dbc")
+	X(attribute_value,      "attribute_value")\
+	X(comment,              "comment")\
+	X(comment_string,       "comment_string")\
+	X(dbc,                  "dbc")
 
 /**@todo This grammar needs expanding and fixing, one addition would be comment lines,
  * which certain tools allow. This consists of a '//' with the rest of the line ignored.
@@ -96,18 +95,20 @@ static const char *dbc_grammar =
 " val_index			   : <integer> ; \n"
 " attribute_definition : \"BA_DEF_\" (<whatever>|<s>|',')* ';' <n> ; \n" /**@note don't care about this, for now*/
 " attribute_value      : \"BA_\" (<whatever>|<s>|',')* ';' <n> ; \n" /**@note don't care about this, for now*/
-" val                  : \"VAL_\" <s>+ <id> <s>+ <name> <s>+ (<val_index> <s>+ <val_name> <s>)* ';' <n> ; \n"
-" comment_string       : <string> ; \n"
+" val_item             : (<integer> <s>+ <string> <s>+) ; \n"
+" val                  : \"VAL_\" <s>+ <id> <s>+ <name> <s>+ <val_item>* ';' <n> ; \n"
+" vals                 : <val>* ; \n"
 " env_var_name         : <ident> ; \n"
+" comment_string       : <string> ; \n"
 " comment              : \"CM_\" <s>+ "
 "                        ( "
-"                            \"SG_\" <s>+ <id> <s>+ <name> <s>+ <comment_string> "
+"                             \"SG_\" <s>+ <id> <s>+ <name> <s>+ <comment_string> "
 "                        |    \"BU_\" <s>+ <name> <s>+ <comment_string> "
 "                        |    \"BO_\" <s>+ <id> <s>+ <comment_string> "
 "                        |    \"EV_\" <s>+ <env_var_name> <s>+ <comment_string> "
 "                        |    <comment_string> "
 "                        ) <s>* ';' <n> ;\n "
-" dbc                  : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> <comment>* <attribute_definition>* <attribute_value>* <val>* ; \n" ;
+" dbc                  : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> <comment>* <attribute_definition>* <attribute_value>* <vals> ; \n" ;
 
 const char *parse_get_grammar(void)
 {


### PR DESCRIPTION
Hi Richard,

This PR add support for parsing the VAL_ elements. Vector uses these fields for assigning textual representation to to signals values.

I think it would be useful to generate enums for the C output. To perform that generation we will need to implement sanitization on the strings to make sure that all enum items are C compilant. To make it easier to review I have separated my patch at this point. 