### PR TITLE
Parse comments and assign them to messages & signals

### DIFF
--- a/can.c
+++ b/can.c
@@ -49,13 +49,13 @@ static void can_msg_delete(can_msg_t *msg)
 
 static void val_delete(val_list_t *val)
 {
-    if(!val)
-        return;
-    for(size_t i = 0; i < val->val_list_item_count; i++) {
-        free(val->val_list_items[i]->name);
-        free(val->val_list_items[i]);
-    }
-    free(val);
+	if(!val)
+		return;
+	for(size_t i = 0; i < val->val_list_item_count; i++) {
+		free(val->val_list_items[i]->name);
+		free(val->val_list_items[i]);
+	}
+	free(val);
 }
 
 static void y_mx_c(mpc_ast_t *ast, signal_t *sig)
@@ -208,23 +208,23 @@ static val_list_t *ast2val(mpc_ast_t *top, mpc_ast_t *ast)
 	}
 
 	val->val_list_item_count = j;
-    val->val_list_items = items;
+	val->val_list_items = items;
 
-    // sort the value items by value
-    if (val->val_list_item_count) {
-        bool bFlip = false;
-        do {
-            bFlip = false;
-            for (size_t i = 0; i < val->val_list_item_count - 1; i++) {
-                if (val->val_list_items[i]->value > val->val_list_items[i + 1]->value) {
-                    val_list_item_t *tmp = val->val_list_items[i];
-                    val->val_list_items[i] = val->val_list_items[i + 1];
-                    val->val_list_items[i + 1] = tmp;
-                    bFlip = true;
-                }
-            }
-        } while (bFlip);
-    }
+	// sort the value items by value
+	if (val->val_list_item_count) {
+		bool bFlip = false;
+		do {
+			bFlip = false;
+			for (size_t i = 0; i < val->val_list_item_count - 1; i++) {
+				if (val->val_list_items[i]->value > val->val_list_items[i + 1]->value) {
+					val_list_item_t *tmp = val->val_list_items[i];
+					val->val_list_items[i] = val->val_list_items[i + 1];
+					val->val_list_items[i + 1] = tmp;
+					bFlip = true;
+				}
+			}
+		} while (bFlip);
+	}
 
 	return val;
 }
@@ -298,14 +298,14 @@ dbc_t *dbc_new(void)
 void dbc_delete(dbc_t *dbc)
 {
 	if(!dbc)
-        return;
-    for(int i = 0; i < dbc->message_count; i++) {
-        can_msg_delete(dbc->messages[i]);
-    }
+		return;
+	for(int i = 0; i < dbc->message_count; i++) {
+		can_msg_delete(dbc->messages[i]);
+	}
 
-    for(size_t i = 0; i < dbc->val_count; i++) {
-        val_delete(dbc->vals[i]);
-    }
+	for(size_t i = 0; i < dbc->val_count; i++) {
+		val_delete(dbc->vals[i]);
+	}
 
 	free(dbc);
 }
@@ -324,6 +324,16 @@ void assign_comment_to_signal(dbc_t *dbc, const char *comment, unsigned message_
 	}
 }
 
+void assign_comment_to_message(dbc_t *dbc, const char *comment, unsigned message_id)
+{
+	for (int i = 0; i<dbc->message_count; i++) {
+		if (dbc->messages[i]->id == message_id) {
+			dbc->messages[i]->comment = duplicate(comment);
+			return;
+		}
+	}
+}
+
 dbc_t *ast2dbc(mpc_ast_t *ast)
 {
 	dbc_t *d = dbc_new();
@@ -336,7 +346,7 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 		d->vals = allocate(sizeof(*d->vals) * (d->val_count+1));
 		if (d->val_count) {
 			int j = 0;
-            for(int i = 0; i >= 0;) {
+			for(int i = 0; i >= 0;) {
 				i = mpc_ast_get_index_lb(vals_ast, "val|>", i);
 				if(i >= 0) {
 					mpc_ast_t *val_ast = mpc_ast_get_child_lb(vals_ast, "val|>", i);
@@ -388,23 +398,31 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 					mpc_ast_t *comment_ast = mpc_ast_get_child_lb(comments_ast, "comment|>", i);
 					if (comments_ast
 						&& comments_ast->children_num > 3) {
-						if (strcmp(comment_ast->children[2]->contents, "SG_") == 0) {
-							// comment assigned to a signal
+						bool to_message = (strcmp(comment_ast->children[2]->contents, "BO_") == 0);
+						bool to_signal = (strcmp(comment_ast->children[2]->contents, "SG_") == 0);
+						if (to_signal || to_message) {
+
 							mpc_ast_t *id   = mpc_ast_get_child(comment_ast, "id|integer|regex");
 							unsigned message_id;
 							int r = sscanf(id->contents, "%u", &message_id);
 							assert(r == 1);
 
 							mpc_ast_t *comment = mpc_ast_get_child(comment_ast, "comment_string|string|>");
-							mpc_ast_t *name = mpc_ast_get_child(comment_ast, "name|ident|regex");
-
-							assign_comment_to_signal(d,
-									comment->children[1]->contents,
-									message_id,
-									name->contents
-									);
-						} else if (strcmp(comment_ast->children[2]->contents, "BO_") == 0) {
-							// comment assigned to a message
+							if (to_signal) {
+								// comment assigned to a signal
+								mpc_ast_t *signal_name = mpc_ast_get_child(comment_ast, "name|ident|regex");
+								assign_comment_to_signal(d,
+										comment->children[1]->contents,
+										message_id,
+										signal_name->contents
+										);
+							} else  {
+								// comment assigned to a message
+								assign_comment_to_message(d,
+										comment->children[1]->contents,
+										message_id
+										);
+							}
 						}
 					}
 					i++;

--- a/can.c
+++ b/can.c
@@ -310,7 +310,7 @@ void dbc_delete(dbc_t *dbc)
 
 void assign_comment_to_signal(dbc_t *dbc, const char *comment, unsigned message_id, const char * signal_name)
 {
-	for (int i = 0; i<dbc->message_count; i++) {
+	for (size_t i = 0; i<dbc->message_count; i++) {
 		if (dbc->messages[i]->id == message_id) {
 			for (size_t j = 0; j<dbc->messages[i]->signal_count; j++) {
 				if (strcmp(dbc->messages[i]->sigs[j]->name, signal_name) == 0) {
@@ -324,7 +324,7 @@ void assign_comment_to_signal(dbc_t *dbc, const char *comment, unsigned message_
 
 void assign_comment_to_message(dbc_t *dbc, const char *comment, unsigned message_id)
 {
-	for (int i = 0; i<dbc->message_count; i++) {
+	for (size_t i = 0; i<dbc->message_count; i++) {
 		if (dbc->messages[i]->id == message_id) {
 			dbc->messages[i]->comment = duplicate(comment);
 			return;

--- a/can.c
+++ b/can.c
@@ -25,6 +25,7 @@ static void signal_delete(signal_t *signal)
 	free(signal->name);
 	free(signal->ecus);
 	free(signal->units);
+	free(signal->comment);
 	free(signal);
 }
 
@@ -42,6 +43,7 @@ static void can_msg_delete(can_msg_t *msg)
 	free(msg->sigs);
 	free(msg->name);
 	free(msg->ecu);
+	free(msg->comment);
 	free(msg);
 }
 
@@ -308,6 +310,20 @@ void dbc_delete(dbc_t *dbc)
 	free(dbc);
 }
 
+void assign_comment_to_signal(dbc_t *dbc, const char *comment, unsigned message_id, const char * signal_name)
+{
+	for (int i = 0; i<dbc->message_count; i++) {
+		if (dbc->messages[i]->id == message_id) {
+			for (size_t j = 0; j<dbc->messages[i]->signal_count; j++) {
+				if (strcmp(dbc->messages[i]->sigs[j]->name, signal_name) == 0) {
+					dbc->messages[i]->sigs[j]->comment = duplicate(comment);
+					return;
+				}
+			}
+		}
+	}
+}
+
 dbc_t *ast2dbc(mpc_ast_t *ast)
 {
 	dbc_t *d = dbc_new();
@@ -320,7 +336,7 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 		d->vals = allocate(sizeof(*d->vals) * (d->val_count+1));
 		if (d->val_count) {
 			int j = 0;
-			for(int i = 0; i >= 0;) {
+            for(int i = 0; i >= 0;) {
 				i = mpc_ast_get_index_lb(vals_ast, "val|>", i);
 				if(i >= 0) {
 					mpc_ast_t *val_ast = mpc_ast_get_child_lb(vals_ast, "val|>", i);
@@ -360,6 +376,42 @@ dbc_t *ast2dbc(mpc_ast_t *ast)
 	int i = mpc_ast_get_index_lb(ast, "sigval|>", 0);
 	if (i >= 0)
 		d->use_float = true;
+
+	// find and store the vals into the dbc: they will be assigned to
+	// signals later
+	mpc_ast_t *comments_ast = mpc_ast_get_child_lb(ast, "comments|>", 0);
+	if (comments_ast) {
+		if (comments_ast->children_num) {
+			for(int i = 0; i >= 0;) {
+				i = mpc_ast_get_index_lb(comments_ast, "comment|>", i);
+				if(i >= 0) {
+					mpc_ast_t *comment_ast = mpc_ast_get_child_lb(comments_ast, "comment|>", i);
+					if (comments_ast
+						&& comments_ast->children_num > 3) {
+						if (strcmp(comment_ast->children[2]->contents, "SG_") == 0) {
+							// comment assigned to a signal
+							mpc_ast_t *id   = mpc_ast_get_child(comment_ast, "id|integer|regex");
+							unsigned message_id;
+							int r = sscanf(id->contents, "%u", &message_id);
+							assert(r == 1);
+
+							mpc_ast_t *comment = mpc_ast_get_child(comment_ast, "comment_string|string|>");
+							mpc_ast_t *name = mpc_ast_get_child(comment_ast, "name|ident|regex");
+
+							assign_comment_to_signal(d,
+									comment->children[1]->contents,
+									message_id,
+									name->contents
+									);
+						} else if (strcmp(comment_ast->children[2]->contents, "BO_") == 0) {
+							// comment assigned to a message
+						}
+					}
+					i++;
+				}
+			}
+		}
+	}
 
 	return d;
 }

--- a/can.h
+++ b/can.h
@@ -53,6 +53,7 @@ typedef struct {
 	unsigned switchval;  /**< if is_multiplexed, this will contain the
 			       value that decodes this signal for the multiplexor */
 	val_list_t *val_list;
+	char *comment;
 } signal_t;
 
 typedef struct {
@@ -63,6 +64,7 @@ typedef struct {
 	size_t signal_count; /**< number of signals */
 	unsigned dlc;  /**< length of CAN message 0-8 bytes */
 	unsigned id;   /**< identifier, 11 or 29 bit */
+	char *comment;
 } can_msg_t;
 
 typedef struct {

--- a/parse.c
+++ b/parse.c
@@ -46,6 +46,7 @@ static mpc_ast_t *_parse_dbc_file_by_handle(const char *name, FILE *handle);
 	X(attribute_definition, "attribute_definition")\
 	X(attribute_value,      "attribute_value")\
 	X(comment,              "comment")\
+    X(comments,             "comments")\
 	X(comment_string,       "comment_string")\
 	X(dbc,                  "dbc")
 
@@ -108,7 +109,8 @@ static const char *dbc_grammar =
 "                        |    \"EV_\" <s>+ <env_var_name> <s>+ <comment_string> "
 "                        |    <comment_string> "
 "                        ) <s>* ';' <n> ;\n "
-" dbc                  : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> <comment>* <attribute_definition>* <attribute_value>* <vals> ; \n" ;
+" comments              : <comment>* ; "
+" dbc                   : <version> <symbols> <bs> <ecus> <values>* <n>* <messages> <comments> <attribute_definition>* <attribute_value>* <vals> ; \n" ;
 
 const char *parse_get_grammar(void)
 {


### PR DESCRIPTION
This PR add support for parsing the CM_ BO_ and CM_ SG_ comments and assign them to the relevant messages/signals.

In the terms of C code generation these comments are generated to the header in the following format:

Messages:
```
/* This message gives information about the motor RPM. */
typedef struct {
	uint16_t Motor_RPM; /* scaling 1.0, offset 0.0, units none  */
} can_0x98ffae01_Commanded_Motor_RPM_t;
```

Signals:
```
typedef struct {
	uint16_t Diagnostics; /* scaling 1.0, offset 0.0, units none  */
	uint8_t Hardware_Version; /* scaling 1.0, offset 0.0, units none  */
	uint8_t Software_Version; /* scaling 1.0, offset 0.0, units none  */
	/* Operating_Voltage: In 100 mV units */
	/* scaling 1.0, offset 0.0, units 100mV  */*
	uint8_t Operating_Voltage;
} can_0x98ffab01_System_Information_t;
```

I am under the impression that it is not the most sophisticated way to show comments and scaling, so we might consider to generate doxygen compatible comments. 