### PR TITLE
Extract DBC version info

### DIFF
--- a/2c.c
+++ b/2c.c
@@ -1113,6 +1113,7 @@ int dbc2c(dbc_t *dbc, FILE *c, FILE *h, const char *name, dbc2c_options_t *copts
 		"/* If the contents of this file have caused breaking changes for you, you could try using\n"
 		"   an older version of the generator. You can specify this on the command line with\n"
 		"   the -n option. */\n"
+		"\n//DBC Version: `Version(\"%s\")`\n\n"
 		"#define DBCC_GENERATOR_VERSION (%d)\n\n"
 		"#include <stdint.h>\n"
 		"%s\n\n"
@@ -1121,6 +1122,7 @@ int dbc2c(dbc_t *dbc, FILE *c, FILE *h, const char *name, dbc2c_options_t *copts
 		"#endif\n\n",
 		file_guard,
 		file_guard,
+		dbc->dbc_version ? dbc->dbc_version : "",
 		copts->version,
 		copts->generate_print   ? "#include <stdio.h>"  : "") < 0)
 			return -1;

--- a/can.h
+++ b/can.h
@@ -90,6 +90,7 @@ typedef struct {
 	size_t mul_val_count; /**< count of mul_vals*/
 	mul_val_list_t **mul_vals; /**< multiplexed value list; used for multiplexed signals in DBC file */
 	int version;          /**< version information used for generating files (not just C) */
+	char *dbc_version;    /**< Raw version string from DBC file's "VERSION" line (e.g. "1.0"), may be NULL if undefined */
 } dbc_t;
 
 dbc_t *ast2dbc(mpc_ast_t *ast);


### PR DESCRIPTION
I discovered that the AST syntax tree has version information parsed from the DBC file, but I noticed that the generated C file lacked this information, so I added it.