### PR TITLE
Support multiple multiplex ranges

### DIFF
--- a/2c.c
+++ b/2c.c
@@ -507,11 +507,21 @@ static void recursively_process_multiplexed(signal_t *sig, FILE *c, const char *
 			fprintf(c, "} else ");
 		}
 		mul_val_list_t *mul_val = sig->mux_vals[i];
-		if (mul_val->min_value == mul_val->max_value) {
-			fprintf(c, "if (o->%s.%s == %u) {\n", name, sig->name, mul_val->min_value);
-		} else {
-			fprintf(c, "if (o->%s.%s >= %u && o->%s.%s <= %u) {\n", name, sig->name, mul_val->min_value, name, sig->name, mul_val->max_value);
+
+		fprintf(c, "if (");
+		for (size_t j = 0; j<mul_val->range_num; j++) {
+			if (j > 0) {
+				fprintf(c, " || \n");
+				fprintf(c, "%s\t", indent);
+			}
+			if (mul_val->ranges[j]->min_value == mul_val->ranges[j]->max_value) {
+						fprintf(c, "o->%s.%s == %u", name, sig->name, mul_val->ranges[j]->min_value);
+			} else {
+						fprintf(c, "(%u <= o->%s.%s  && o->%s.%s <= %u)", mul_val->ranges[j]->min_value, name, sig->name, name, sig->name, mul_val->ranges[j]->max_value);
+			}
 		}
+		fprintf(c, ") {\n");
+
 		recursively_process_multiplexed(sig->muxed[i], c, name, serialize, indent_level + 1);
 	}
 

--- a/can.c
+++ b/can.c
@@ -69,6 +69,9 @@ static void mul_val_delete(mul_val_list_t *mul_val)
 		return;
 	free(mul_val->multiplexed);
 	free(mul_val->multiplexor);
+	for (size_t i = 0; i < mul_val->range_num; i++) {
+		free(mul_val->ranges[i]);
+	}
 	free(mul_val);
 }
 
@@ -262,20 +265,66 @@ static mul_val_list_t *ast2mul_val(mpc_ast_t *top, mpc_ast_t *ast)
 	mpc_ast_t *multiplexor = mpc_ast_get_child_lb(ast, "name|ident|regex", i+1);
 	mul_val->multiplexor = duplicate(multiplexor->contents);
 
-	i = mpc_ast_get_index_lb(ast, "integer|regex", i);
-	mpc_ast_t *first_value = mpc_ast_get_child_lb(ast, "integer|regex", i);
-	r = sscanf(first_value->contents,  "%u",  &mul_val->min_value);
-	assert(r == 1);
+	mpc_ast_t *mul_ranges_ast = mpc_ast_get_child_lb(ast, "mul_ranges|>", 0);
+	if (mul_ranges_ast && mul_ranges_ast->children_num) {
+		mul_val_range_pair **ranges = allocate(sizeof(*ranges) * (mul_ranges_ast->children_num+1));
+		int j = 0;
+		for (int i = 0; i >= 0;) {
+			mpc_ast_t *mul_range = mpc_ast_get_child_lb(mul_ranges_ast, "mul_range|>", i);
+			if (mul_range) {
+				mul_val_range_pair *range = allocate(sizeof(mul_val_range_pair));
 
-	mpc_ast_t *second_value = mpc_ast_get_child_lb(ast, "integer|regex", i+1);
-	r = sscanf(second_value->contents,  "%u",  &mul_val->max_value);
-	assert(r == 1);
+				int k = 0;
+				k = mpc_ast_get_index_lb(mul_range, "integer|regex", 0);
+				mpc_ast_t *first_value = mpc_ast_get_child_lb(mul_range, "integer|regex", k);
+				r = sscanf(first_value->contents,  "%u",  &range->min_value);
+				assert(r == 1);
 
-	// swap inverted values
-	if (mul_val->min_value > mul_val->max_value) {
-		int tmp = mul_val->min_value;
-		mul_val->min_value = mul_val->max_value;
-		mul_val->max_value = tmp;
+				mpc_ast_t *second_value = mpc_ast_get_child_lb(mul_range, "integer|regex", k+1);
+				r = sscanf(second_value->contents,  "%u",  &range->max_value);
+				assert(r == 1);
+
+				// swap inverted values
+				if (range->min_value > range->max_value) {
+					int tmp = range->min_value;
+					range->min_value = range->max_value;
+					range->max_value = tmp;
+				}
+
+				ranges[j++] = range;
+				i++;
+			} else {
+				break;
+			}
+		}
+		mul_val->range_num = j;
+		mul_val->ranges = ranges;
+	} else {
+		mpc_ast_t *mul_range = mpc_ast_get_child_lb(ast, "mul_ranges|mul_range|>", 0);
+		if (mul_range) {
+			mul_val->range_num = 1;
+			mul_val_range_pair *range = allocate(sizeof(mul_val_range_pair));
+
+			int k = 0;
+			k = mpc_ast_get_index_lb(mul_range, "integer|regex", 0);
+			mpc_ast_t *first_value = mpc_ast_get_child_lb(mul_range, "integer|regex", k);
+			r = sscanf(first_value->contents,  "%u",  &range->min_value);
+			assert(r == 1);
+
+			mpc_ast_t *second_value = mpc_ast_get_child_lb(mul_range, "integer|regex", k+1);
+			r = sscanf(second_value->contents,  "%u",  &range->max_value);
+			assert(r == 1);
+
+			// swap inverted values
+			if (range->min_value > range->max_value) {
+				int tmp = range->min_value;
+				range->min_value = range->max_value;
+				range->max_value = tmp;
+			}
+
+			mul_val->ranges = allocate(sizeof(mul_val_range_pair*));
+			mul_val->ranges[0] = range;
+		}
 	}
 
 	return mul_val;
@@ -328,7 +377,7 @@ static can_msg_t *ast2msg(mpc_ast_t *top, mpc_ast_t *ast, dbc_t *dbc)
 	// assign val-s to the signals
 	for (size_t i = 0; i < c->signal_count; i++) {
 		for (size_t j = 0; j<dbc->val_count; j++) {
-			if (dbc->vals[j]->id == c->id && strcmp(dbc->vals[j]->name, c->sigs[i]->name) == 0) {
+			if (dbc->vals[j]->id == (c->id | (unsigned long)c->is_extended << 31) && strcmp(dbc->vals[j]->name, c->sigs[i]->name) == 0) {
 				c->sigs[i]->val_list = dbc->vals[j];
 				break;
 			}
@@ -339,11 +388,17 @@ static can_msg_t *ast2msg(mpc_ast_t *top, mpc_ast_t *ast, dbc_t *dbc)
 	for (size_t i = 0; i < c->signal_count; i++) {
 		for (size_t j = 0; j<dbc->mul_val_count; j++) {
 			if (dbc->mul_vals[j]->id == (c->id | (unsigned long)c->is_extended << 31) && strcmp(dbc->mul_vals[j]->multiplexed, c->sigs[i]->name) == 0) {
-				if (c->sigs[i]->switchval > dbc->mul_vals[j]->max_value || c->sigs[i]->switchval < dbc->mul_vals[j]->min_value)
+				bool muxMatch = false;
+				for (size_t k = 0; k<dbc->mul_vals[j]->range_num; k++) {
+					if (dbc->mul_vals[j]->ranges[k]->min_value <= c->sigs[i]->switchval && c->sigs[i]->switchval <= dbc->mul_vals[j]->ranges[k]->max_value) {
+						muxMatch = true;
+						break;
+					}
+				}
+				if (!muxMatch)
 					error("The multiplex value is wrong on message %s for signal %s (fix your DBC file)", c->name, c->sigs[i]->name);
 
 				c->sigs[i]->is_multiplexed = true;
-
 				for(size_t k = 0; k < c->signal_count; k++) {
 					if (strcmp(c->sigs[k]->name, dbc->mul_vals[j]->multiplexor) == 0) {
 						size_t last = c->sigs[k]->mul_num++;

--- a/can.h
+++ b/can.h
@@ -36,10 +36,15 @@ typedef struct {
 } val_list_t;
 
 typedef struct {
+    unsigned min_value;
+    unsigned max_value;
+} mul_val_range_pair;
+
+typedef struct {
 	char *multiplexed;
 	char *multiplexor;
-	unsigned min_value;
-	unsigned max_value;
+	size_t range_num;
+	mul_val_range_pair **ranges;
 	unsigned id;   /**< identifier, 11 or 29 bit */
 } mul_val_list_t;
 

--- a/mul-val.dbc
+++ b/mul-val.dbc
@@ -33,8 +33,12 @@ NS_ :
 
 BS_:
 
-BU_: Vector__XXX
+BU_:
 
+
+BO_ 0 extended_multiplex_w_ranges: 2 Vector__XXX
+ SG_ muxed_w_ranges m1 : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ muxer_w_multiple_ranges M : 0|8@1+ (1,0) [0|255] "" Vector__XXX
 
 BO_ 1682 extended_multiplex: 8 Vector__XXX
  SG_ sig1 : 0|2@1+ (1,0) [0|0] "" Vector__XXX
@@ -45,6 +49,10 @@ BO_ 1682 extended_multiplex: 8 Vector__XXX
  SG_ muxed1 m1 : 32|32@1+ (1,0) [0|0] "" Vector__XXX
  SG_ muxed2 m4 : 32|32@1+ (1,0) [0|0] "" Vector__XXX
 
+
+
+
+SG_MUL_VAL_ 0 muxed_w_ranges muxer_w_multiple_ranges 1-2, 66-66, 255-255;
 SG_MUL_VAL_ 1682 muxed_muxer simple_muxer 9216-9216;
 SG_MUL_VAL_ 1682 muxed1 muxed_muxer 1-1;
 SG_MUL_VAL_ 1682 muxed2 muxed_muxer 4-4;

--- a/parse.c
+++ b/parse.c
@@ -47,6 +47,8 @@ static mpc_ast_t *_parse_dbc_file_by_handle(const char *name, FILE *handle);
 	X(vals,                 "vals")\
 	X(mul_val,              "mul_val")\
 	X(mul_vals,             "mul_vals")\
+	X(mul_range,            "mul_range")\
+	X(mul_ranges,           "mul_ranges")\
 	X(attribute_definition, "attribute_definition")\
 	X(attribute_value,      "attribute_value")\
 	X(comment,              "comment")\
@@ -98,10 +100,12 @@ static const char *dbc_grammar =
 " attribute_definition : \"BA_DEF_\" (<whatever>|<s>|',')* ';' <n> ; \n"
 " attribute_value      : \"BA_\" (<whatever>|<s>|',')* ';' <n> ; \n"
 " val_item             : (<s>+ <integer> <s>+ <string>) ; \n"
-" val                  : \"VAL_\" <s>+ <id> <s>+ <name> <val_item>* <s>* ';' <n> ; \n"
-" vals                 : <val>* ; \n"
-" mul_val     : \"SG_MUL_VAL_\" <s>+ <id> <s>+ <name> <s>+ <name> <s>+ <integer> '-' <integer> ';' <n> ; \n"
-" mul_vals     : <mul_val>* ; \n"
+" val                  : \"VAL_\" <s>+ <id> <s>+ <name> <val_item>* <s>* ';' <n>* ; \n"
+" vals                 : <val>*; \n"
+" mul_range            : (<integer> '-' <integer> ','? <s>*) ; \n"
+" mul_ranges           : <mul_range>* ; \n"
+" mul_val              : \"SG_MUL_VAL_\" <s>+ <id> <s>+ <name> <s>+ <name> <s>+ <mul_ranges> ';' <n> ; \n"
+" mul_vals             : <mul_val>* ; \n"
 " env_var_name         : <ident> ; \n"
 " comment_string       : <string> ; \n"
 " comment              : \"CM_\" <s>+ "


### PR DESCRIPTION
Vector CanDB++ DBC editor is capable to assign multiplex ranges separated with hypens:

<img width="363" height="127" alt="kép" src="https://github.com/user-attachments/assets/f4ec9ebb-7d8f-4414-846e-045cc05c579c" />

This is represented  in the DBC file in the following manner:
<img width="643" height="71" alt="kép" src="https://github.com/user-attachments/assets/9dd9e2a4-5b07-472f-9bf6-677c380460bd" />

This PR adds support to this construct